### PR TITLE
adds clarifications to README to specify minimum gh version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # gh-prs
 
-`gh` cli extension to display a dashboard or pull requests by filters you care about.
+A `gh` cli extension to display a dashboard with pull requests by filters you care about.
 
 ![demo](https://github.com/dlvhdr/gh-prs/blob/8621183574c573e4077360b5027ffea70999b921/demo.gif)
 
 ## Installation
 
-1. Install gh cli - see the [installation instructions](https://github.com/cli/cli#installation)
+Installation requires a minimum version (2.0.0) of the the Github CLI to support extensions.
+
+1. Install the `gh cli`- see the [installation/upgrade instructions](https://github.com/cli/cli#installation)
 
 2. Install this extension:
 
@@ -16,13 +18,16 @@ gh extension install dlvhdr/gh-prs
 
 ## Configuring
 
-Configuration is done in the `sections.yml` file under the extension's directory.
-Each section is defined by a top level array item and has the following properies:
+Configuration is provided within a `sections.yml` file under the extension's directory. If the configuration file is missing, a prompt to create it will be displayed to when running `gh prs`.
+
+Each section is defined by a top level array item and has the following properties:
+
 - title - shown in the TUI
 - repos - a list of repos to enumerate
 - filters - how the repo's PRs should be filtered - these are plain [github filters](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests)
 
-Example `sections.yml` file: 
+Example `sections.yml` file:
+
 ```yml
 - title: My Pull Requests
   repos:
@@ -43,11 +48,13 @@ Example `sections.yml` file:
 ## Usage
 
 Run:
+
 ```sh
 gh prs
 ```
 
 Then press <kbd>?</kbd> for help.
 
-# Author
+## Author
+
 Dolev Hadar dolevc2@gmail.com

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ gh extension install dlvhdr/gh-prs
 
 ## Configuring
 
-Configuration is provided within a `sections.yml` file under the extension's directory. If the configuration file is missing, a prompt to create it will be displayed to when running `gh prs`.
+Configuration is provided within a `sections.yml` file under the extension's directory. If the configuration file is missing, a prompt to create it will be displayed when running `gh prs`.
 
 Each section is defined by a top level array item and has the following properties:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A `gh` cli extension to display a dashboard with pull requests by filters you ca
 
 Installation requires a minimum version (2.0.0) of the the Github CLI to support extensions.
 
-1. Install the `gh cli`- see the [installation/upgrade instructions](https://github.com/cli/cli#installation)
+1. Install the `gh cli` - see the [installation/upgrade instructions](https://github.com/cli/cli#installation)
 
 2. Install this extension:
 


### PR DESCRIPTION
### What's Changed

adds clarifications to the README following first time setup of the extension:

### Technical Description

* specify a minimum `gh` cli version e.g. v2.0.0 is when extensions were introduced. 
* adds notes on `sections.yml` configuration location being provided in a prompt when running `gh prs`.
* fixes formatting, grammar, and typos in README