### PR TITLE
add option to not create the debug.log file

### DIFF
--- a/gh-prs.go
+++ b/gh-prs.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -10,18 +11,33 @@ import (
 	"dlvhdr/gh-prs/ui"
 )
 
-func createModel() (ui.Model, *os.File) {
-	loggerFile, err := tea.LogToFile("debug.log", "debug")
-	if err != nil {
-		fmt.Println("Error setting up logger")
+func createModel(debug bool) (ui.Model, *os.File) {
+	var loggerFile *os.File
+	var err error
+
+	if debug {
+		loggerFile, err = tea.LogToFile("debug.log", "debug")
+		if err != nil {
+			fmt.Println("Error setting up logger")
+		}
 	}
 
 	return ui.NewModel(loggerFile), loggerFile
 }
 
 func main() {
-	model, logger := createModel()
-	defer logger.Close()
+	debug := flag.Bool(
+		"debug",
+		false,
+		"passing this flag will allow writing debug output to debug.log",
+	)
+	flag.Parse()
+
+	model, logger := createModel(*debug)
+	if logger != nil {
+		defer logger.Close()
+	}
+
 	p := tea.NewProgram(
 		model,
 		tea.WithAltScreen(),


### PR DESCRIPTION
By passing --debug, the file will be created.
Otherwise, it won't and no debugging will be possible.