### PR TITLE
Support darwin-amd64

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -11,7 +11,7 @@ if [ "${tag}" == "" ]; then
 fi
 
 rm -rf dist
-GOOS=darwin GOARCH=amd64 go build -o "dist/darwin-x86_64"
+GOOS=darwin GOARCH=amd64 go build -o "dist/darwin-amd64"
 GOOS=darwin GOARCH=arm64 go build -o "dist/darwin-arm64"
 GOOS=linux GOARCH=386 go build -o "dist/linux-i386"
 GOOS=linux GOARCH=amd64 go build -o "dist/linux-x86_64"


### PR DESCRIPTION
There was a bug in the release script that didn't publish the darwin-amd64 exe