### PR TITLE
Ignore archived PRs

### DIFF
--- a/data/api.go
+++ b/data/api.go
@@ -107,7 +107,7 @@ type Reviews struct {
 }
 
 func makeQuery(query string) string {
-	return fmt.Sprintf("is:pr %s", query)
+	return fmt.Sprintf("is:pr archived:false %s", query)
 }
 
 func FetchRepoPullRequests(query string, limit int) ([]PullRequestData, error) {


### PR DESCRIPTION
Resolves #80

# Summary

Adding `archived:false` as part of the default GitHub query.

The current shown PRs include archived PRs that are irrelevant to monitor.
The default query should follow the default query on
https://github.com/pulls

`is:open is:pr author:<username> archived:false`

`is:open author:@me` is already covered by the default configuration YAML.

## How did you test this change?
Compiled and run it locally.

## Images/Videos
Before (https://github.com/ori-amizur/introspector/pull/30 is archived)
![Screenshot from 2022-02-03 18-24-28](https://user-images.githubusercontent.com/29873449/152384384-86e67d90-39ea-4363-8727-8e8157ea2862.png)

